### PR TITLE
Switch to Llama‑3.1 Swallow model

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ RAG（Retrieval-Augmented Generation）を使用したチャットボットと�
 - **埋め込みモデル**: sentence-transformers/all-MiniLM-L6-v2
 - **PDF処理**: PyMuPDF (fitz)
 - **テキスト分割**: LangChain RecursiveCharacterTextSplitter
-- **LLMモデル**: yf591/llm-jp-3-13b-it-1（オプション）
+ - **LLMモデル**: tokyotech-llm/Llama-3.1-Swallow-8B-Instruct-v0.1（オプション）
 
 ### 📚 ライブラリの役割と技術選定理由
 
@@ -107,7 +107,7 @@ graph TB
     M --> N{回答生成方式}
     N -->|シンプル版| O[テンプレート回答]
     N -->|LLM版| P[transformers + torch]
-    P --> Q[llm-jp-3-13b-it-1]
+    P --> Q[Llama-3.1-Swallow-8B-Instruct]
     Q --> R[AI生成回答]
     
     O --> S[Streamlit UI]
@@ -364,10 +364,10 @@ rag_chatbot_demo/
 
 ## 🔧 LLMモデル情報（app.py使用時）
 
-- **モデル名**: yf591/llm-jp-3-13b-it-1
-- **ベースモデル**: llm-jp/llm-jp-3-13b
-- **ライセンス**: CC-BY-NC-SA
-- **特徴**: Unslothで高速化されたファインチューニング済みモデル
+- **モデル名**: tokyotech-llm/Llama-3.1-Swallow-8B-Instruct-v0.1
+- **ベースモデル**: Meta Llama 3.1 8B
+- **ライセンス**: Llama 3 Community License
+- **特徴**: 日本語指示データでファインチューニングされたモデル
 - **量子化**: 4bit量子化（QLoRA）対応
 
 ### プロンプト形式

--- a/app.py
+++ b/app.py
@@ -67,7 +67,7 @@ def main():
         - 福山市観光パンフレット
         
         **使用モデル:**
-        - LLM: yf591/llm-jp-3-13b-it-1
+        - LLM: tokyotech-llm/Llama-3.1-Swallow-8B-Instruct-v0.1
         - 埋め込み: all-MiniLM-L6-v2
         - 量子化: 4bit QLoRA
         """)

--- a/app_original.py
+++ b/app_original.py
@@ -47,7 +47,7 @@ def main():
         - 福山市観光パンフレット
         
         **使用モデル:**
-        - LLM: llm-jp-3-13b-it-1
+        - LLM: tokyotech-llm/Llama-3.1-Swallow-8B-Instruct-v0.1
         - 埋め込み: all-MiniLM-L6-v2
         """)
         

--- a/rag_system.py
+++ b/rag_system.py
@@ -10,7 +10,8 @@ class RAGSystem:
     def __init__(self, vector_store_path: str = "./vector_store", hf_token: Optional[str] = None):
         self.vector_store_path = vector_store_path
         self.hf_token = hf_token
-        self.model_name = "yf591/llm-jp-3-13b-it-1"
+        # デフォルトのLLMモデルをHugging Faceの公開モデルに変更
+        self.model_name = "tokyotech-llm/Llama-3.1-Swallow-8B-Instruct-v0.1"
         
         # 埋め込みモデルを初期化（GPUが利用可能な場合はGPU使用）
         device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit
-transformers>=4.36.0
+transformers>=4.41.0
 torch>=2.0.0
 langchain>=0.3.0
 langchain-community>=0.3.0

--- a/requirements_colab.txt
+++ b/requirements_colab.txt
@@ -1,5 +1,5 @@
 streamlit
-transformers>=4.36.0
+transformers>=4.41.0
 torch>=2.0.0
 langchain>=0.3.0
 langchain-community>=0.3.0


### PR DESCRIPTION
## Summary
- update RAG system default LLM to HuggingFace tokyotech-llm/Llama-3.1-Swallow-8B-Instruct-v0.1
- bump transformers requirement for Llama 3 support
- update app UI and docs to show new model

## Testing
- `python -m py_compile rag_system.py`
- `python -m py_compile app.py app_original.py`

------
https://chatgpt.com/codex/tasks/task_b_6848fd1eeca8832f9afe6b54ff5b32c9